### PR TITLE
Update Windows project files to include upstream changes from SoyLib

### DIFF
--- a/PopH264.visualstudio/PopH264.vcxproj
+++ b/PopH264.visualstudio/PopH264.vcxproj
@@ -98,6 +98,7 @@
     <ClCompile Include="..\Source\SoyLib\src\SoyFilesystem.cpp" />
     <ClCompile Include="..\Source\SoyLib\src\SoyFourcc.cpp" />
     <ClCompile Include="..\Source\SoyLib\src\SoyH264.cpp" />
+    <ClCompile Include="..\Source\SoyLib\src\SoyHevc.cpp" />
     <ClCompile Include="..\Source\SoyLib\src\SoyPixels.cpp" />
     <ClCompile Include="..\Source\SoyLib\src\SoyPlatform.cpp" />
     <ClCompile Include="..\Source\SoyLib\src\SoyRuntimeLibrary.cpp" />
@@ -157,6 +158,7 @@
     <ClInclude Include="..\Source\PopH264TestData.h" />
     <ClInclude Include="..\Source\SoyAvf.h" />
     <ClInclude Include="..\Source\SoyLib\src\SoyFilesystem.h" />
+    <ClInclude Include="..\Source\SoyLib\src\SoyHevc.hpp" />
     <ClInclude Include="..\Source\SoyLib\src\SoyPlatform.h" />
     <ClInclude Include="..\Source\SoyLib\src\SoyRuntimeLibrary.h" />
     <ClInclude Include="..\Source\TDecoderInstance.h" />

--- a/PopH264.visualstudio/PopH264.vcxproj.filters
+++ b/PopH264.visualstudio/PopH264.vcxproj.filters
@@ -225,6 +225,9 @@
     <ClCompile Include="..\Source\PopH264_Version.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\Source\SoyLib\src\SoyHevc.cpp">
+      <Filter>SoyLib</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\Source\SoyLib\src\Array.hpp">
@@ -487,6 +490,9 @@
     </ClInclude>
     <ClInclude Include="..\Source\FileReader.hpp">
       <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Source\SoyLib\src\SoyHevc.hpp">
+      <Filter>SoyLib</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Current main branch is missing a reference to SoyHevc.cpp in the SoyLib.vcxproj, causing a build error for undefined symbols 
in TDecoder.cpp for `Hevc::IsNaluHevc`

Adding these files to the project file appears to fix the build.
